### PR TITLE
🔧 Update Lavalink plugin config

### DIFF
--- a/lavalink/application.template.yml
+++ b/lavalink/application.template.yml
@@ -3,7 +3,8 @@ server:
   address: 0.0.0.0
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.5.0"
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.2.0"
+      repository: "https://maven.lavalink.dev/releases"
       snapshot: false
   server:
     password: null
@@ -23,16 +24,6 @@ lavalink:
     soundcloudSearchEnabled: true
     gc-warnings: true
 plugins:
-  youtube:
-    enabled: true
-    allowSearch: true
-    allowDirectVideoIds: true
-    allowDirectPlaylistIds: true
-    clients:
-      - MUSIC
-      - ANDROID_TESTSUITE
-      - WEB
-      - TVHTML5EMBEDDED
   lavasrc:
     providers:
       - 'ytsearch:"%ISRC%"'
@@ -40,6 +31,7 @@ plugins:
     sources:
       spotify: true
       applemusic: false
+      youtube: true
     spotify:
       clientId: null
       clientSecret: null


### PR DESCRIPTION
Updating Lavalink plugin configuration to consolidate the plugins under one. This plugin handles all of the sources that we require (including YouTube and Spotify). This also therefore fixes an issue where Spotify links do not play properly from MOCBOT.

This change helps to keep the Lavalink container small and concise without redundant plugins.