### PR TITLE
🐛 Fix Docker compose healthcheck link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - backend
       - api
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://localhost:8000/healthcheck || exit 1
+      test: wget --no-verbose --tries=1 --spider http://127.0.0.1:8000/healthcheck || exit 1
       interval: 5s
       start_period: 2s
       start_interval: 3s


### PR DESCRIPTION
Fixes an issue with the docker compose where the healthcheck link was referring to localhost. It has been changed to 127.0.0.1 for greater compatability across different systems.